### PR TITLE
Make report file name variable

### DIFF
--- a/ci-run.sh
+++ b/ci-run.sh
@@ -5,8 +5,9 @@ set -o nounset
 set -o pipefail
 
 readonly URL=$1
+readonly LABEL=$2
 
-OUTPUT_FILE=/out/lighthouse.json
+OUTPUT_FILE=/out/$LABEL.json
 
 lighthouse \
   $URL \


### PR DESCRIPTION
This adds a (required) argument to ci-run.sh for setting the output file name