### PR TITLE
Add lighthouse-plugin-greenhouse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 AS builder
+FROM golang:1.12 AS builder
 
 RUN go get github.com/giantswarm/lighthouse-keeper && \
     go build github.com/giantswarm/lighthouse-keeper
@@ -15,14 +15,11 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
     rm google-chrome-stable_current_amd64.deb
 
 # Install NodeJS 8 and Lighthouse Module
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-RUN npm install -g lighthouse
-
-# see https://github.com/andreasonny83/lighthouse-ci
-RUN npm install -g lighthouse-ci
+RUN npm install -g lighthouse lighthouse-plugin-greenhouse lighthouse-ci
 
 COPY --from=builder /go/lighthouse-keeper /usr/local/bin/lighthouse-keeper
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ docker run --rm \
         --output=json \
         --output-path=/out/lighthouse.json \
         --emulated-form-factor desktop \
+        --plugins=lighthouse-plugin-greenhouse \
         --chrome-flags="--headless --no-sandbox"
 ```
 

--- a/ci-run.sh
+++ b/ci-run.sh
@@ -15,6 +15,7 @@ lighthouse \
   --emulated-form-factor desktop \
   --quiet \
   --chrome-flags="--headless --no-sandbox --ignore-certificate-errors"
+  --plugins=lighthouse-plugin-greenhouse
 
 if [[ ! -e $OUTPUT_FILE ]]; then
   echo "No lighthouse report written"


### PR DESCRIPTION
This PR adds support for the [lighthouse-plugin-greenhouse](https://github.com/thegreenwebfoundation/lighthouse-plugin-greenhouse) plugin, which attempts to assess the energy mix and carbon footprint of a site.

Example call:

```bash
URL=https://gruene.de/
mkdir ./dev-shm
docker run --rm -ti \
    -v $PWD:/out \
    -v $PWD/dev-shm:/dev/shm \
    quay.io/giantswarm/lighthouse \
    lighthouse \
    $URL \
        --no-enable-error-reporting \
        --output=json \
        --output-path=/out/lighthouse.json \
        --emulated-form-factor desktop \
        --plugins=lighthouse-plugin-greenhouse \
        --chrome-flags="--headless --no-sandbox"
```

Some terminal output

```
[ { green: true,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'gruene.de',
    data: true,
    hostedby: 'Google Inc.',
    hostedbyid: 595,
    hostedbywebsite: 'www.google.com',
    partner: null },
  { green: false,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'www.gruene.de',
    data: true },
  { green: false,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'gruene.matomo.cloud',
    data: true },
  { green: false,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'cdn.gruene.de',
    data: true },
  { green: false,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'cms.gruene.de',
    data: true },
  { green: false,
    checked_on: '2019-07-26T21:03:42+02:00',
    url: 'actionnetwork.org',
    data: true } ]
```
